### PR TITLE
fix undefined reference to `pthread_create'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+CFLAGS = -pthread
 CPPFLAGS = -I include -Wall
 
 src = $(wildcard src/*.c)


### PR DESCRIPTION
```sh
cc  -I include -Wall -c src/tcp_socket.c -o build/tcp_socket.o
cc  -I include -Wall -c src/icmpv4.c -o build/icmpv4.o
cc  -I include -Wall -c src/netdev.c -o build/netdev.o
cc  -I include -Wall -c src/tcp.c -o build/tcp.o
cc  -I include -Wall -c src/cli.c -o build/cli.o
cc  -I include -Wall -c src/arp.c -o build/arp.o
cc  -I include -Wall -c src/ethernet.c -o build/ethernet.o
cc  -I include -Wall -c src/tuntap_if.c -o build/tuntap_if.o
cc  -I include -Wall -c src/main.c -o build/main.o
cc  -I include -Wall -c src/ipv4.c -o build/ipv4.o
cc  -I include -Wall -c src/curl.c -o build/curl.o
cc  -I include -Wall -c src/utils.c -o build/utils.o
cc   build/socket.o  build/tcp_socket.o  build/icmpv4.o  build/netdev.o  build/tcp.o  build/cli.o  build/arp.o  build/ethernet.o  build/tuntap_if.o  build/main.o  build/ipv4.o  build/curl.o  build/utils.o -o lvl-ip
build/main.o: In function `run_threads':
main.c:(.text+0x120): undefined reference to `pthread_create'
main.c:(.text+0x168): undefined reference to `pthread_create'
build/main.o: In function `wait_for_threads':
main.c:(.text+0x1b7): undefined reference to `pthread_join'
collect2: error: ld returned 1 exit status
Makefile:9: recipe for target 'lvl-ip' failed
make: *** [lvl-ip] Error 1
```
@saminiir 