### PR TITLE
Refactor/use worker threads in timer dispatch

### DIFF
--- a/include/socket.h
+++ b/include/socket.h
@@ -66,7 +66,7 @@ struct socket {
     struct sock *sk;
     struct sock_ops *ops;
     struct wait_lock sleep;
-    pthread_mutex_t lock;
+    pthread_rwlock_t lock;
 };
 
 void *socket_ipc_open(void *args);

--- a/include/socket.h
+++ b/include/socket.h
@@ -66,6 +66,7 @@ struct socket {
     struct sock *sk;
     struct sock_ops *ops;
     struct wait_lock sleep;
+    pthread_mutex_t lock;
 };
 
 void *socket_ipc_open(void *args);

--- a/include/tcp.h
+++ b/include/tcp.h
@@ -215,7 +215,7 @@ int tcp_input_state(struct sock *sk, struct tcphdr *th, struct sk_buff *skb);
 int tcp_send_synack(struct sock *sk);
 int tcp_send_next(struct sock *sk, int amount);
 int tcp_send_ack(struct sock *sk);
-void tcp_send_delack(uint32_t ts, void *arg);
+void *tcp_send_delack(void *arg);
 int tcp_queue_fin(struct sock *sk);
 int tcp_send_fin(struct sock *sk);
 int tcp_send(struct tcp_sock *tsk, const void *buf, int len);

--- a/include/timer.h
+++ b/include/timer.h
@@ -15,12 +15,13 @@ struct timer {
     int refcnt;
     uint32_t expires;
     int cancelled;
-    void (*handler)(uint32_t, void *);
+    void *(*handler)(void *);
     void *arg;
+    pthread_mutex_t lock;
 };
 
-struct timer *timer_add(uint32_t expire, void (*handler)(uint32_t, void *), void *arg);
-void timer_oneshot(uint32_t expire, void (*handler)(uint32_t, void *), void *arg);
+struct timer *timer_add(uint32_t expire, void *(*handler)(void *), void *arg);
+void timer_oneshot(uint32_t expire, void *(*handler)(void *), void *arg);
 void timer_release(struct timer *t);
 void timer_cancel(struct timer *t);
 void *timers_start();

--- a/src/arp.c
+++ b/src/arp.c
@@ -49,14 +49,19 @@ static int update_arp_translation_table(struct arp_hdr *hdr, struct arp_ipv4 *da
     struct list_head *item;
     struct arp_cache_entry *entry;
 
+    pthread_mutex_lock(&lock);
     list_for_each(item, &arp_cache) {
         entry = list_entry(item, struct arp_cache_entry, list);
 
         if (entry->hwtype == hdr->hwtype && entry->sip == data->sip) {
             memcpy(entry->smac, data->smac, 6);
+            pthread_mutex_unlock(&lock);
+            
             return 1;
         }
     }
+
+    pthread_mutex_unlock(&lock);
     
     return 0;
 }

--- a/src/arp.c
+++ b/src/arp.c
@@ -9,6 +9,7 @@
 
 static uint8_t broadcast_hw[] = { 0xff, 0xff, 0xff, 0xff, 0xff, 0xff };
 static LIST_HEAD(arp_cache);
+static pthread_mutex_t lock = PTHREAD_MUTEX_INITIALIZER;
 
 static struct sk_buff *arp_alloc_skb()
 {
@@ -36,7 +37,9 @@ static int insert_arp_translation_table(struct arp_hdr *hdr, struct arp_ipv4 *da
 {
     struct arp_cache_entry *entry = arp_entry_alloc(hdr, data);
 
+    pthread_mutex_lock(&lock);
     list_add_tail(&entry->list, &arp_cache);
+    pthread_mutex_unlock(&lock);
 
     return 0;
 }
@@ -202,6 +205,7 @@ unsigned char* arp_get_hwaddr(uint32_t sip)
     struct list_head *item;
     struct arp_cache_entry *entry;
     
+    pthread_mutex_lock(&lock);
     list_for_each(item, &arp_cache) {
         entry = list_entry(item, struct arp_cache_entry, list);
 
@@ -209,9 +213,14 @@ unsigned char* arp_get_hwaddr(uint32_t sip)
             entry->sip == sip) {
             arpcache_dbg("entry", entry);
 
-            return entry->smac;
+            uint8_t *copy = entry->smac;
+            pthread_mutex_unlock(&lock);
+
+            return copy;
         }
     }
+
+    pthread_mutex_unlock(&lock);
 
     return NULL;
 }

--- a/src/inet.c
+++ b/src/inet.c
@@ -113,9 +113,11 @@ static int inet_stream_connect(struct socket *sock, const struct sockaddr *addr,
         if (sock->flags & O_NONBLOCK) {
             goto out;
         }
-        
-        wait_sleep(&sock->sleep);
 
+        pthread_rwlock_unlock(&sock->lock);
+        wait_sleep(&sock->sleep);
+        pthread_rwlock_wrlock(&sock->lock);
+        
         switch (sk->err) {
         case -ETIMEDOUT:
         case -ECONNREFUSED:

--- a/src/ipc.c
+++ b/src/ipc.c
@@ -513,8 +513,8 @@ void *start_ipc_listener()
         }
 
         struct ipc_thread *th = ipc_alloc_thread(datasock);
-        
-        if (pthread_create(&th->id, NULL, &socket_ipc_open, &datasock) != 0) {
+
+        if (pthread_create(&th->id, NULL, &socket_ipc_open, &th->sock) != 0) {
             print_err("Error on socket thread creation\n");
             exit(1);
         };

--- a/src/socket.c
+++ b/src/socket.c
@@ -24,11 +24,16 @@ static struct socket *alloc_socket(pid_t pid)
     list_init(&sock->list);
 
     sock->pid = pid;
+
+    pthread_rwlock_wrlock(&slock);
     sock->fd = fd++;
+    pthread_rwlock_unlock(&slock);
+
     sock->state = SS_UNCONNECTED;
     sock->ops = NULL;
     sock->flags = O_RDWR;
     wait_init(&sock->sleep);
+    pthread_mutex_init(&sock->lock, NULL);
     
     return sock;
 }
@@ -46,20 +51,22 @@ int socket_free(struct socket *sock)
     return 0;
 }
 
-static void socket_garbage_collect(uint32_t ts, void *arg)
+static void *socket_garbage_collect(void *arg)
 {
     struct socket *sock = (struct socket *)arg;
 
-    socket_dbg(sock, "Garbage collecting (freeing) socket");
-
     pthread_rwlock_wrlock(&slock);
+    pthread_mutex_lock(&sock->lock);
+    socket_dbg(sock, "Garbage collecting (freeing) socket");
 
     list_del(&sock->list);
     sock_amount--;
 
+    pthread_mutex_unlock(&sock->lock);    
     pthread_rwlock_unlock(&slock);
-    
     socket_free(sock);
+
+    return NULL;
 }
 
 int socket_delete(struct socket *sock)
@@ -93,12 +100,17 @@ static struct socket *get_socket(pid_t pid, uint32_t fd)
     struct list_head *item;
     struct socket *sock = NULL;
 
+    pthread_rwlock_rdlock(&slock);
     list_for_each(item, &sockets) {
         sock = list_entry(item, struct socket, list);
-        if (sock->pid == pid && sock->fd == fd) return sock;
+        if (sock->pid == pid && sock->fd == fd) goto out;
     }
     
-    return NULL;
+    sock = NULL;
+
+out:
+    pthread_rwlock_unlock(&slock);
+    return sock;
 }
 
 struct socket *socket_lookup(uint16_t remoteport, uint16_t localport)
@@ -136,7 +148,9 @@ void socket_debug()
 
     list_for_each(item, &sockets) {
         sock = list_entry(item, struct socket, list);
+        pthread_mutex_lock(&sock->lock);
         socket_dbg(sock, "");
+        pthread_mutex_unlock(&sock->lock);
     }
 
     pthread_rwlock_unlock(&slock);
@@ -177,9 +191,12 @@ int _socket(pid_t pid, int domain, int type, int protocol)
     list_add_tail(&sock->list, &sockets);
     sock_amount++;
 
+    pthread_mutex_lock(&sock->lock);
     pthread_rwlock_unlock(&slock);
+    int rc = sock->fd;
+    pthread_mutex_unlock(&sock->lock);
 
-    return sock->fd;
+    return rc;
 
 abort_socket:
     socket_free(sock);
@@ -195,7 +212,11 @@ int _connect(pid_t pid, int sockfd, const struct sockaddr *addr, socklen_t addrl
         return -EBADF;
     }
 
-    return sock->ops->connect(sock, addr, addrlen, 0);
+    pthread_mutex_lock(&sock->lock);
+    int rc = sock->ops->connect(sock, addr, addrlen, 0);
+    pthread_mutex_unlock(&sock->lock);
+    
+    return rc;
 }
 
 int _write(pid_t pid, int sockfd, const void *buf, const unsigned int count)
@@ -207,7 +228,11 @@ int _write(pid_t pid, int sockfd, const void *buf, const unsigned int count)
         return -EBADF;
     }
 
-    return sock->ops->write(sock, buf, count);
+    pthread_mutex_lock(&sock->lock);
+    int rc = sock->ops->write(sock, buf, count);
+    pthread_mutex_unlock(&sock->lock);
+
+    return rc;
 }
 
 int _read(pid_t pid, int sockfd, void *buf, const unsigned int count)
@@ -219,7 +244,11 @@ int _read(pid_t pid, int sockfd, void *buf, const unsigned int count)
         return -EBADF;
     }
 
-    return sock->ops->read(sock, buf, count);
+    pthread_mutex_lock(&sock->lock);
+    int rc = sock->ops->read(sock, buf, count);
+    pthread_mutex_unlock(&sock->lock);
+
+    return rc;
 }
 
 int _close(pid_t pid, int sockfd)
@@ -231,7 +260,12 @@ int _close(pid_t pid, int sockfd)
         return -EBADF;
     }
 
-    return sock->ops->close(sock);
+
+    pthread_mutex_lock(&sock->lock);
+    int rc = sock->ops->close(sock);
+    pthread_mutex_unlock(&sock->lock);
+
+    return rc;
 }
 
 int _poll(pid_t pid, struct pollfd fds[], nfds_t nfds, int timeout)
@@ -247,10 +281,12 @@ int _poll(pid_t pid, struct pollfd fds[], nfds_t nfds, int timeout)
                 return -EBADF;
             }
 
+            pthread_mutex_lock(&sock->lock);
             poll->revents = sock->sk->poll_events & (poll->events | POLLHUP | POLLERR | POLLNVAL);
             if (poll->revents > 0) {
                 polled++;
             }
+            pthread_mutex_unlock(&sock->lock);
         }
 
         if (polled > 0 || timeout == 0) {
@@ -279,22 +315,30 @@ int _fcntl(pid_t pid, int fildes, int cmd, ...)
         return -EBADF;
     }
 
+    pthread_mutex_lock(&sock->lock);
     va_list ap;
+    int rc = 0;
 
     switch (cmd) {
     case F_GETFL:
-        return sock->flags;
+        rc = sock->flags;
+        goto out;
     case F_SETFL:
         va_start(ap, cmd);
         sock->flags = va_arg(ap, int);
         va_end(ap);
-        return 0;
+        rc = 0;
+        goto out;
     default:
-        return -1;
-
+        rc = -1;
+        goto out;
     }
 
-    return -1;
+    rc = -1;
+
+out:
+    pthread_mutex_unlock(&sock->lock);
+    return rc;
 }
 
 int _getsockopt(pid_t pid, int fd, int level, int optname, void *optval, socklen_t *optlen)
@@ -306,25 +350,33 @@ int _getsockopt(pid_t pid, int fd, int level, int optname, void *optval, socklen
         return -EBADF;
     }
 
+    int rc = 0;
+
+    pthread_mutex_lock(&sock->lock);
     switch (level) {
     case SOL_SOCKET:
         switch (optname) {
         case SO_ERROR:
             *optlen = 4;
             *(int *)optval = sock->sk->err;
-            return 0;
+            rc = 0;
+            break;
         default:
             print_err("Getsockopt unsupported optname %d\n", optname);
-            return -ENOPROTOOPT;
+            rc =  -ENOPROTOOPT;
+            break;
         }
         
         break;
     default:
         print_err("Getsockopt: Unsupported level %d\n", level);
-        return -EINVAL;
+        rc = -EINVAL;
+        break;
     }
 
-    return 0;
+    pthread_mutex_unlock(&sock->lock);
+
+    return rc;
 }
 
 int _getpeername(pid_t pid, int socket, struct sockaddr *restrict address,
@@ -337,7 +389,9 @@ int _getpeername(pid_t pid, int socket, struct sockaddr *restrict address,
         return -EBADF;
     }
 
+    pthread_mutex_lock(&sock->lock);
     int rc = sock->ops->getpeername(sock, address, address_len);
+    pthread_mutex_unlock(&sock->lock);
 
     return rc;
 }
@@ -352,7 +406,9 @@ int _getsockname(pid_t pid, int socket, struct sockaddr *restrict address,
         return -EBADF;
     }
 
+    pthread_mutex_lock(&sock->lock);
     int rc = sock->ops->getsockname(sock, address, address_len);
+    pthread_mutex_unlock(&sock->lock);
 
     return rc;
 }

--- a/src/tcp_input.c
+++ b/src/tcp_input.c
@@ -481,7 +481,9 @@ int tcp_receive(struct tcp_sock *tsk, void *buf, int len)
             
             break;
         } else {
+            pthread_rwlock_unlock(&sock->lock);
             wait_sleep(&tsk->sk.recv_wait);
+            pthread_rwlock_wrlock(&sock->lock);
         }
     }
 

--- a/src/timer.c
+++ b/src/timer.c
@@ -7,6 +7,29 @@ static int tick = 0;
 static pthread_mutex_t lock = PTHREAD_MUTEX_INITIALIZER;
 static pthread_rwlock_t rwlock = PTHREAD_RWLOCK_INITIALIZER;
 
+#ifdef DEBUG_TIMER
+static void timer_debug()
+{
+    struct list_head *item;
+    int cnt = 0;
+
+    pthread_mutex_lock(&lock);
+
+    list_for_each(item, &timers) {
+        cnt++;
+    }
+
+    pthread_mutex_unlock(&lock);
+
+    print_debug("TIMERS: Total amount currently %d", cnt);
+}
+#else
+static void timer_debug()
+{
+    return;
+}
+#endif
+
 static void timer_free(struct timer *t)
 {
     int rc = 0;
@@ -152,6 +175,7 @@ void *timers_start()
 
         if (tick % 5000 == 0) {
             socket_debug();
+            timer_debug();
         } 
     }
 }

--- a/src/timer.c
+++ b/src/timer.c
@@ -58,8 +58,10 @@ static void timers_tick()
 {
     struct list_head *item, *tmp = NULL;
     struct timer *t = NULL;
+    int rc = 0;
 
-    if (pthread_mutex_trylock(&lock) == EBUSY) {
+    if ((rc = pthread_mutex_lock(&lock)) != 0) {
+        print_err("Timer tick lock not acquired: %s\n", strerror(rc));
         return;
     };
     

--- a/src/timer.c
+++ b/src/timer.c
@@ -45,8 +45,6 @@ static void timers_tick()
         
         t = list_entry(item, struct timer, list);
 
-        pthread_mutex_lock(&t->lock);
-
         if (!t->cancelled && t->expires < tick) {
             t->cancelled = 1;
             pthread_t th;
@@ -56,8 +54,6 @@ static void timers_tick()
         if (t->cancelled && t->refcnt == 0) {
             timer_free(t);
         }
-
-        pthread_mutex_unlock(&t->lock);
     }
 
     pthread_mutex_unlock(&lock);

--- a/src/timer.c
+++ b/src/timer.c
@@ -164,12 +164,12 @@ void timer_cancel(struct timer *t)
 void *timers_start()
 {
     while (1) {
-        if (usleep(1000) != 0) {
+        if (usleep(10000) != 0) {
             perror("Timer usleep");
         }
 
         pthread_rwlock_wrlock(&rwlock);
-        tick++;
+        tick += 10;
         pthread_rwlock_unlock(&rwlock);
         timers_tick();
 

--- a/tests/suites/tcp/env-delayed
+++ b/tests/suites/tcp/env-delayed
@@ -15,7 +15,7 @@ function setup {
     /usr/bin/env python2.7 -m SimpleHTTPServer >/dev/null 2>&1 &
     httpserver="$!"
 
-    sleep 1
+    sleep 2
 
     tc qdisc add dev tap0 root netem delay 2000ms 
 }

--- a/tests/suites/tcp/env-duplication
+++ b/tests/suites/tcp/env-duplication
@@ -15,7 +15,7 @@ function setup {
     /usr/bin/env python2.7 -m SimpleHTTPServer >/dev/null 2>&1 &
     httpserver="$!"
 
-    sleep 1
+    sleep 2
 
     tc qdisc add dev tap0 root netem duplicate 50%
 }

--- a/tests/suites/tcp/env-lossy
+++ b/tests/suites/tcp/env-lossy
@@ -15,7 +15,7 @@ function setup {
     /usr/bin/env python2.7 -m SimpleHTTPServer >/dev/null 2>&1 &
     httpserver="$!"
 
-    sleep 1
+    sleep 2
 
     tc qdisc add dev tap0 root netem loss 25%
 }

--- a/tests/suites/tcp/env-normal
+++ b/tests/suites/tcp/env-normal
@@ -15,7 +15,7 @@ function setup {
     /usr/bin/env python2.7 -m SimpleHTTPServer >/dev/null 2>&1 &
     httpserver="$!"
 
-    sleep 1
+    sleep 2
 }
 
 function teardown {


### PR DESCRIPTION
Introduces stability improvements and removes coding errors related to multithreading:

* Locking of a socket and its operations is now coarse-grained: Acquire the socket lock on every operation. This makes the multithreading much simpler and most of the race conditions revealed by ThreadSanitizer were removed.
* Timer thread now dispatches worker threads. This simplifies the locking scheme because the timer thread previously easily deadlocked on a socket's operation.
* Timer tick resolution is now 10 ms, since with `usleep(1000)` most of the time was spent just iterating over the timers.

Most of the mutexes are now unused, and should be removed in the near future. Maybe in this changeset even.