### PR TITLE
Quick fixes to sender MSS, socket locking

### DIFF
--- a/include/socket.h
+++ b/include/socket.h
@@ -66,6 +66,7 @@ struct socket {
     struct sock *sk;
     struct sock_ops *ops;
     struct wait_lock sleep;
+    pthread_rwlock_t lock;
 };
 
 void *socket_ipc_open(void *args);

--- a/include/tcp.h
+++ b/include/tcp.h
@@ -215,7 +215,7 @@ int tcp_input_state(struct sock *sk, struct tcphdr *th, struct sk_buff *skb);
 int tcp_send_synack(struct sock *sk);
 int tcp_send_next(struct sock *sk, int amount);
 int tcp_send_ack(struct sock *sk);
-void tcp_send_delack(uint32_t ts, void *arg);
+void *tcp_send_delack(void *arg);
 int tcp_queue_fin(struct sock *sk);
 int tcp_send_fin(struct sock *sk);
 int tcp_send(struct tcp_sock *tsk, const void *buf, int len);

--- a/include/timer.h
+++ b/include/timer.h
@@ -15,12 +15,13 @@ struct timer {
     int refcnt;
     uint32_t expires;
     int cancelled;
-    void (*handler)(uint32_t, void *);
+    void *(*handler)(void *);
     void *arg;
+    pthread_mutex_t lock;
 };
 
-struct timer *timer_add(uint32_t expire, void (*handler)(uint32_t, void *), void *arg);
-void timer_oneshot(uint32_t expire, void (*handler)(uint32_t, void *), void *arg);
+struct timer *timer_add(uint32_t expire, void *(*handler)(void *), void *arg);
+void timer_oneshot(uint32_t expire, void *(*handler)(void *), void *arg);
 void timer_release(struct timer *t);
 void timer_cancel(struct timer *t);
 void *timers_start();

--- a/src/inet.c
+++ b/src/inet.c
@@ -113,9 +113,11 @@ static int inet_stream_connect(struct socket *sock, const struct sockaddr *addr,
         if (sock->flags & O_NONBLOCK) {
             goto out;
         }
-        
-        wait_sleep(&sock->sleep);
 
+        pthread_rwlock_unlock(&sock->lock);
+        wait_sleep(&sock->sleep);
+        pthread_rwlock_wrlock(&sock->lock);
+        
         switch (sk->err) {
         case -ETIMEDOUT:
         case -ECONNREFUSED:

--- a/src/ipc.c
+++ b/src/ipc.c
@@ -3,7 +3,7 @@
 #include "ipc.h"
 #include "socket.h"
 
-#define IPC_BUFLEN 4096
+#define IPC_BUFLEN 8192
 
 static LIST_HEAD(sockets);
 static pthread_mutex_t lock = PTHREAD_MUTEX_INITIALIZER;

--- a/src/ipc.c
+++ b/src/ipc.c
@@ -513,8 +513,8 @@ void *start_ipc_listener()
         }
 
         struct ipc_thread *th = ipc_alloc_thread(datasock);
-        
-        if (pthread_create(&th->id, NULL, &socket_ipc_open, &datasock) != 0) {
+
+        if (pthread_create(&th->id, NULL, &socket_ipc_open, &th->sock) != 0) {
             print_err("Error on socket thread creation\n");
             exit(1);
         };

--- a/src/tcp.c
+++ b/src/tcp.c
@@ -123,7 +123,7 @@ struct sock *tcp_alloc_sock()
 
     /* TODO: Determine mss properly */
     tsk->rmss = 1460;
-    tsk->smss = 1460;
+    tsk->smss = 1300;
 
     tsk->cwnd = 0;
     tsk->inflight = 0;

--- a/src/tcp_input.c
+++ b/src/tcp_input.c
@@ -481,7 +481,9 @@ int tcp_receive(struct tcp_sock *tsk, void *buf, int len)
             
             break;
         } else {
+            pthread_rwlock_unlock(&sock->lock);
             wait_sleep(&tsk->sk.recv_wait);
+            pthread_rwlock_wrlock(&sock->lock);
         }
     }
 

--- a/src/tcp_output.c
+++ b/src/tcp_output.c
@@ -5,7 +5,7 @@
 #include "skbuff.h"
 #include "timer.h"
 
-static void tcp_retransmission_timeout(uint32_t ts, void *arg);
+static void *tcp_retransmission_timeout(void *arg);
 
 static struct sk_buff *tcp_alloc_skb(int optlen, int size)
 {
@@ -131,15 +131,19 @@ int tcp_send_synack(struct sock *sk)
 }
 
 /* Routine for timer-invoked delayed acknowledgment */
-void tcp_send_delack(uint32_t ts, void *arg)
+void *tcp_send_delack(void *arg)
 {
     struct sock *sk = (struct sock *) arg;
-    struct tcp_sock *tsk = tcp_sk(sk);
+    pthread_rwlock_wrlock(&sk->sock->lock);
 
+    struct tcp_sock *tsk = tcp_sk(sk);
     tsk->delacks = 0;
     tcp_release_delack_timer(tsk);
-
     tcp_send_ack(sk);
+
+    pthread_rwlock_unlock(&sk->sock->lock);
+
+    return NULL;
 }
 
 int tcp_send_next(struct sock *sk, int amount)
@@ -237,12 +241,13 @@ static void tcp_notify_user(struct sock *sk)
     }
 }
 
-static void tcp_connect_rto(uint32_t ts, void *arg)
+static void *tcp_connect_rto(void *arg)
 {
     struct tcp_sock *tsk = (struct tcp_sock *) arg;
     struct tcb *tcb = &tsk->tcb;
     struct sock *sk = &tsk->sk;
 
+    pthread_rwlock_wrlock(&sk->sock->lock);
     tcp_release_rto_timer(tsk);
 
     if (sk->state == TCP_SYN_SENT) {
@@ -268,14 +273,19 @@ static void tcp_connect_rto(uint32_t ts, void *arg)
     } else {
         print_err("TCP connect RTO triggered even when not in SYNSENT\n");
     }
+
+    pthread_rwlock_unlock(&sk->sock->lock);
+
+    return NULL;
 }
 
-static void tcp_retransmission_timeout(uint32_t ts, void *arg)
+static void *tcp_retransmission_timeout(void *arg)
 {
     struct tcp_sock *tsk = (struct tcp_sock *) arg;
     struct tcb *tcb = &tsk->tcb;
     struct sock *sk = &tsk->sk;
 
+    pthread_rwlock_wrlock(&sk->sock->lock);
     pthread_mutex_lock(&sk->write_queue.lock);
 
     tcp_release_rto_timer(tsk);
@@ -301,7 +311,9 @@ static void tcp_retransmission_timeout(uint32_t ts, void *arg)
 
         tsk->sk.err = -ETIMEDOUT;
         sk->poll_events |= (POLLOUT | POLLERR | POLLHUP);
-        return;
+
+        pthread_rwlock_unlock(&sk->sock->lock);
+        return NULL;
     } else {
         /* RFC 6298: Section 5.5 double RTO time */
         tsk->rto *= 2;
@@ -315,6 +327,9 @@ static void tcp_retransmission_timeout(uint32_t ts, void *arg)
 
 unlock:
     pthread_mutex_unlock(&sk->write_queue.lock);
+    pthread_rwlock_unlock(&sk->sock->lock);
+
+    return NULL;
 }
 
 void tcp_rearm_rto_timer(struct tcp_sock *tsk)

--- a/src/timer.c
+++ b/src/timer.c
@@ -8,8 +8,11 @@ static pthread_mutex_t lock = PTHREAD_MUTEX_INITIALIZER;
 
 static void timer_free(struct timer *t)
 {
-    if (pthread_mutex_trylock(&lock) != 0) {
-        perror("Timer free mutex lock");
+    int rc = 0;
+    if ((rc = pthread_mutex_trylock(&lock)) != 0) {
+        if (rc != EBUSY) {
+            print_err("Timer free mutex lock: %s\n", strerror(rc));
+        }
         return;
     }
 
@@ -89,8 +92,10 @@ struct timer *timer_add(uint32_t expire, void (*handler)(uint32_t, void *), void
 
 void timer_release(struct timer *t)
 {
-    if (pthread_mutex_lock(&lock) != 0) {
-        perror("Timer release lock");
+    int rc = 0;
+    
+    if ((rc = pthread_mutex_lock(&lock)) != 0) {
+        print_err("Timer release lock: %s\n", strerror(rc));
         return;
     };
 
@@ -103,8 +108,10 @@ void timer_release(struct timer *t)
 
 void timer_cancel(struct timer *t)
 {
-    if (pthread_mutex_lock(&lock) != 0) {
-        perror("Timer cancel lock");
+    int rc = 0;
+    
+    if ((rc = pthread_mutex_lock(&lock)) != 0) {
+        print_err("Timer cancel lock: %s\n", strerror(rc));
         return;
     };
 

--- a/src/timer.c
+++ b/src/timer.c
@@ -5,26 +5,41 @@
 static LIST_HEAD(timers);
 static int tick = 0;
 static pthread_mutex_t lock = PTHREAD_MUTEX_INITIALIZER;
+static pthread_rwlock_t rwlock = PTHREAD_RWLOCK_INITIALIZER;
+
+#ifdef DEBUG_TIMER
+static void timer_debug()
+{
+    struct list_head *item;
+    int cnt = 0;
+
+    pthread_mutex_lock(&lock);
+
+    list_for_each(item, &timers) {
+        cnt++;
+    }
+
+    pthread_mutex_unlock(&lock);
+
+    print_debug("TIMERS: Total amount currently %d", cnt);
+}
+#else
+static void timer_debug()
+{
+    return;
+}
+#endif
 
 static void timer_free(struct timer *t)
 {
-    int rc = 0;
-    if ((rc = pthread_mutex_trylock(&lock)) != 0) {
-        if (rc != EBUSY) {
-            print_err("Timer free mutex lock: %s\n", strerror(rc));
-        }
-        return;
-    }
-
-    list_del(&t->list);
+    pthread_mutex_destroy(&t->lock);
     free(t);
-
-    pthread_mutex_unlock(&lock);
 }
 
 static struct timer *timer_alloc()
 {
     struct timer *t = calloc(sizeof(struct timer), 1);
+    pthread_mutex_init(&t->lock, NULL);
 
     return t;
 }
@@ -33,24 +48,50 @@ static void timers_tick()
 {
     struct list_head *item, *tmp = NULL;
     struct timer *t = NULL;
+    int rc = 0;
 
+    if ((rc = pthread_mutex_lock(&lock)) != 0) {
+        print_err("Timer tick lock not acquired: %s\n", strerror(rc));
+        return;
+    };
+    
     list_for_each_safe(item, tmp, &timers) {
+        if (!item) continue;
+        
         t = list_entry(item, struct timer, list);
+
+        if ((rc = pthread_mutex_trylock(&t->lock)) != 0) {
+            if (rc != EBUSY) {
+                print_err("Timer free mutex lock: %s\n", strerror(rc));
+            }
+            
+            continue;
+        }
 
         if (!t->cancelled && t->expires < tick) {
             t->cancelled = 1;
-            t->handler(tick, t->arg);
+            pthread_t th;
+            pthread_create(&th, NULL, t->handler, t->arg);
         }
 
         if (t->cancelled && t->refcnt == 0) {
+            list_del(&t->list);
+            pthread_mutex_unlock(&t->lock);
+
             timer_free(t);
+        } else {
+            pthread_mutex_unlock(&t->lock);
         }
     }
+
+    pthread_mutex_unlock(&lock);
 }
 
-void timer_oneshot(uint32_t expire, void (*handler)(uint32_t, void *), void *arg)
+void timer_oneshot(uint32_t expire, void *(*handler)(void *), void *arg)
 {
     struct timer *t = timer_alloc();
+
+    int tick = timer_get_tick();
 
     t->refcnt = 0;
     t->expires = tick + expire;
@@ -68,9 +109,11 @@ void timer_oneshot(uint32_t expire, void (*handler)(uint32_t, void *), void *arg
     pthread_mutex_unlock(&lock);
 }
 
-struct timer *timer_add(uint32_t expire, void (*handler)(uint32_t, void *), void *arg)
+struct timer *timer_add(uint32_t expire, void *(*handler)(void *), void *arg)
 {
     struct timer *t = timer_alloc();
+
+    int tick = timer_get_tick();
 
     t->refcnt = 1;
     t->expires = tick + expire;
@@ -93,53 +136,60 @@ struct timer *timer_add(uint32_t expire, void (*handler)(uint32_t, void *), void
 void timer_release(struct timer *t)
 {
     int rc = 0;
+
+    if (!t) return;
     
-    if ((rc = pthread_mutex_lock(&lock)) != 0) {
+    if ((rc = pthread_mutex_lock(&t->lock)) != 0) {
         print_err("Timer release lock: %s\n", strerror(rc));
         return;
     };
 
-    if (t) {
-        t->refcnt--;
-    }
+    t->refcnt--;
     
-    pthread_mutex_unlock(&lock);
+    pthread_mutex_unlock(&t->lock);
 }
 
 void timer_cancel(struct timer *t)
 {
     int rc = 0;
     
-    if ((rc = pthread_mutex_lock(&lock)) != 0) {
+    if (!t) return;
+
+    if ((rc = pthread_mutex_lock(&t->lock)) != 0) {
         print_err("Timer cancel lock: %s\n", strerror(rc));
         return;
     };
 
-    if (t) {
-        t->refcnt--;
-        t->cancelled = 1;
-    }
-    
-    pthread_mutex_unlock(&lock);
+    t->refcnt--;
+    t->cancelled = 1;
+        
+    pthread_mutex_unlock(&t->lock);
 }
 
 void *timers_start()
 {
     while (1) {
-        if (usleep(1000) != 0) {
+        if (usleep(10000) != 0) {
             perror("Timer usleep");
         }
 
-        tick++;
+        pthread_rwlock_wrlock(&rwlock);
+        tick += 10;
+        pthread_rwlock_unlock(&rwlock);
         timers_tick();
 
         if (tick % 5000 == 0) {
             socket_debug();
+            timer_debug();
         } 
     }
 }
 
 int timer_get_tick()
 {
-    return tick;
+    int copy = 0;
+    pthread_rwlock_rdlock(&rwlock);
+    copy = tick;
+    pthread_rwlock_unlock(&rwlock);
+    return copy;
 }

--- a/tests/suites/tcp/env-delayed
+++ b/tests/suites/tcp/env-delayed
@@ -15,7 +15,7 @@ function setup {
     /usr/bin/env python2.7 -m SimpleHTTPServer >/dev/null 2>&1 &
     httpserver="$!"
 
-    sleep 2
+    sleep 10
 
     tc qdisc add dev tap0 root netem delay 2000ms 
 }

--- a/tests/suites/tcp/env-delayed
+++ b/tests/suites/tcp/env-delayed
@@ -15,7 +15,7 @@ function setup {
     /usr/bin/env python2.7 -m SimpleHTTPServer >/dev/null 2>&1 &
     httpserver="$!"
 
-    sleep 1
+    sleep 2
 
     tc qdisc add dev tap0 root netem delay 2000ms 
 }

--- a/tests/suites/tcp/env-duplication
+++ b/tests/suites/tcp/env-duplication
@@ -15,7 +15,7 @@ function setup {
     /usr/bin/env python2.7 -m SimpleHTTPServer >/dev/null 2>&1 &
     httpserver="$!"
 
-    sleep 1
+    sleep 2
 
     tc qdisc add dev tap0 root netem duplicate 50%
 }

--- a/tests/suites/tcp/env-duplication
+++ b/tests/suites/tcp/env-duplication
@@ -15,7 +15,7 @@ function setup {
     /usr/bin/env python2.7 -m SimpleHTTPServer >/dev/null 2>&1 &
     httpserver="$!"
 
-    sleep 2
+    sleep 10
 
     tc qdisc add dev tap0 root netem duplicate 50%
 }

--- a/tests/suites/tcp/env-duplication
+++ b/tests/suites/tcp/env-duplication
@@ -15,7 +15,7 @@ function setup {
     /usr/bin/env python2.7 -m SimpleHTTPServer >/dev/null 2>&1 &
     httpserver="$!"
 
-    sleep 10
+    sleep 15
 
     tc qdisc add dev tap0 root netem duplicate 50%
 }

--- a/tests/suites/tcp/env-lossy
+++ b/tests/suites/tcp/env-lossy
@@ -15,7 +15,7 @@ function setup {
     /usr/bin/env python2.7 -m SimpleHTTPServer >/dev/null 2>&1 &
     httpserver="$!"
 
-    sleep 1
+    sleep 2
 
     tc qdisc add dev tap0 root netem loss 25%
 }

--- a/tests/suites/tcp/env-lossy
+++ b/tests/suites/tcp/env-lossy
@@ -15,7 +15,7 @@ function setup {
     /usr/bin/env python2.7 -m SimpleHTTPServer >/dev/null 2>&1 &
     httpserver="$!"
 
-    sleep 2
+    sleep 10
 
     tc qdisc add dev tap0 root netem loss 25%
 }

--- a/tests/suites/tcp/env-normal
+++ b/tests/suites/tcp/env-normal
@@ -15,7 +15,7 @@ function setup {
     /usr/bin/env python2.7 -m SimpleHTTPServer >/dev/null 2>&1 &
     httpserver="$!"
 
-    sleep 1
+    sleep 2
 }
 
 function teardown {

--- a/tests/suites/tcp/env-normal
+++ b/tests/suites/tcp/env-normal
@@ -15,7 +15,7 @@ function setup {
     /usr/bin/env python2.7 -m SimpleHTTPServer >/dev/null 2>&1 &
     httpserver="$!"
 
-    sleep 2
+    sleep 10
 }
 
 function teardown {

--- a/tests/utils/common
+++ b/tests/utils/common
@@ -9,7 +9,7 @@ function start_stack {
     "$repo/lvl-ip" >/dev/null &
     stackip="$!"
 
-    sleep 1
+    sleep 2
 
     for i in {1..10}; do
         ping -c1 -w1 10.0.0.5 >/dev/null || continue


### PR DESCRIPTION
Stability improvements with improved (simplified) locking scheme. See https://github.com/saminiir/level-ip/pull/10

Artificially lowered and hardcoded sender MSS, in order to accommodate lower ranges. Correctly determining the MSS is in TODO.

End-to-end test suites have their hackish sleeps increased, since TravisCI VM sporadically fails. A proper test framework is in TODO.