### PR TITLE
Threading fixes, async test suites and TCP SACK receiver-side implementation

### DIFF
--- a/Documentation/getting-started.md
+++ b/Documentation/getting-started.md
@@ -4,7 +4,7 @@ Level-IP is a TCP/IP stack that is run as a single daemon process on your Linux 
 
 To interface applications against Level-IP, a wrapper library for standard libc calls is provided. This wrapper can then be used with existing binaries such as `curl`, `surf` and `firefox` to redirect communications to Level-IP.
 
-DISCLAIMER: Level-IP is not a production-ready networking stack, and does not intend to be one. The nature of lower-level networking imposes a great responsiblity to the software and any security vulnerabilites can be disastrous. Hence, do not run Level-IP for extended periods of time, purely because it has bugs (and as all software, will continue to have them).
+DISCLAIMER: Level-IP is not a production-ready networking stack, and does not intend to be one. The nature of lower-level networking imposes a great responsiblity to the software and any security vulnerabilities can be disastrous. Hence, do not run Level-IP for extended periods of time, purely because it has bugs (and as all software, will continue to have them).
 
 # Building
 

--- a/Makefile
+++ b/Makefile
@@ -13,15 +13,20 @@ lvl-ip: $(obj)
 build/%.o: src/%.c ${headers}
 	$(CC) $(CFLAGS) $(CPPFLAGS) -c $< -o $@
 
-debug: CFLAGS+= -DDEBUG_SOCKET -DDEBUG_TCP -g -fsanitize=address
+debug: CFLAGS+= -DDEBUG_SOCKET -DDEBUG_TCP -g -fsanitize=thread
 debug: lvl-ip
 
-all: lvl-ip
+apps:
 	$(MAKE) -C tools
 	$(MAKE) -C apps/curl
 	$(MAKE) -C apps/curl-poll
 
-test: all
+all: lvl-ip apps
+	$(MAKE) -C tools
+	$(MAKE) -C apps/curl
+	$(MAKE) -C apps/curl-poll
+
+test: debug apps
 	@echo
 	@echo "Networking capabilites are required for test dependencies:"
 	which arping | sudo xargs setcap cap_net_raw=ep

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ CPPFLAGS = -I include -Wall -Werror -pthread
 src = $(wildcard src/*.c)
 obj = $(patsubst src/%.c, build/%.o, $(src))
 headers = $(wildcard include/*.h)
+apps = apps/curl/curl
 
 lvl-ip: $(obj)
 	$(CC) $(CFLAGS) $(CPPFLAGS) $(obj) -o lvl-ip
@@ -16,15 +17,12 @@ build/%.o: src/%.c ${headers}
 debug: CFLAGS+= -DDEBUG_SOCKET -DDEBUG_TCP -g -fsanitize=thread
 debug: lvl-ip
 
-apps:
+apps: $(apps)
 	$(MAKE) -C tools
 	$(MAKE) -C apps/curl
 	$(MAKE) -C apps/curl-poll
 
 all: lvl-ip apps
-	$(MAKE) -C tools
-	$(MAKE) -C apps/curl
-	$(MAKE) -C apps/curl-poll
 
 test: debug apps
 	@echo

--- a/include/ip.h
+++ b/include/ip.h
@@ -16,11 +16,11 @@
 #define ip_dbg(msg, hdr)                                                \
     do {                                                                \
         print_debug("ip "msg" (ihl: %hhu version: %hhu tos: %hhu "   \
-                    "len %hu id: %hu flags: %hhu frag_offset: %hu ttl: %hhu " \
+                    "len %hu id: %hu frag_offset: %hu ttl: %hhu " \
                     "proto: %hhu csum: %hx " \
                     "saddr: %hhu.%hhu.%hhu.%hhu daddr: %hhu.%hhu.%hhu.%hhu)", \
                     hdr->ihl,                                           \
-                    hdr->version, hdr->tos, hdr->len, hdr->id, hdr->flags, \
+                    hdr->version, hdr->tos, hdr->len, hdr->id,          \
                     hdr->frag_offset, hdr->ttl, hdr->proto, hdr->csum,   \
                     hdr->saddr >> 24, hdr->saddr >> 16, hdr->saddr >> 8, hdr->saddr >> 0, \
                     hdr->daddr >> 24, hdr->daddr >> 16, hdr->daddr >> 8, hdr->daddr >> 0); \

--- a/include/ip.h
+++ b/include/ip.h
@@ -35,8 +35,7 @@ struct iphdr {
     uint8_t tos;
     uint16_t len;
     uint16_t id;
-    uint16_t flags : 3;
-    uint16_t frag_offset : 13;
+    uint16_t frag_offset;
     uint8_t ttl;
     uint8_t proto;
     uint16_t csum;

--- a/include/route.h
+++ b/include/route.h
@@ -5,9 +5,9 @@
 
 #define RT_LOOPBACK 0x01
 #define RT_GATEWAY  0x02
-#define RT_HOST     0x03
-#define RT_REJECT   0x04
-#define RT_UP       0x05
+#define RT_HOST     0x04
+#define RT_REJECT   0x08
+#define RT_UP       0x10
 
 struct rtentry {
     struct list_head list;

--- a/include/skbuff.h
+++ b/include/skbuff.h
@@ -26,7 +26,6 @@ struct sk_buff_head {
     struct list_head head;
 
     uint32_t qlen;
-    pthread_mutex_t lock;
 };
 
 struct sk_buff *alloc_skb(unsigned int size);
@@ -45,7 +44,6 @@ static inline void skb_queue_init(struct sk_buff_head *list)
 {
     list_init(&list->head);
     list->qlen = 0;
-    pthread_mutex_init(&list->lock, NULL);
 }
 
 static inline void skb_queue_add(struct sk_buff_head *list, struct sk_buff *new, struct sk_buff *next)

--- a/include/skbuff.h
+++ b/include/skbuff.h
@@ -48,7 +48,7 @@ static inline void skb_queue_init(struct sk_buff_head *list)
 
 static inline void skb_queue_add(struct sk_buff_head *list, struct sk_buff *new, struct sk_buff *next)
 {
-    list_add(&new->list, &next->list);
+    list_add_tail(&new->list, &next->list);
     list->qlen += 1;
 }
 

--- a/include/sock.h
+++ b/include/sock.h
@@ -25,7 +25,6 @@ struct sock {
     struct wait_lock recv_wait;
     struct sk_buff_head receive_queue;
     struct sk_buff_head write_queue;
-    pthread_mutex_t lock;
     int protocol;
     int state;
     int err;

--- a/include/socket.h
+++ b/include/socket.h
@@ -9,11 +9,11 @@
 #define socket_dbg(sock, msg, ...)                                      \
     do {                                                                \
         print_debug("Socket fd %d pid %d state %d sk_state %d flags %d poll %d sport %d dport %d " \
-                    "sock-sleep %d sk-sleep %d recv-q %d send-q %d: "msg,    \
+                    "recv-q %d send-q %d: "msg,    \
                     sock->fd, sock->pid, sock->state, sock->sk->state, sock->flags, \
                     sock->sk->poll_events,                              \
-                    sock->sk->sport, sock->sk->dport, sock->sleep.sleeping, \
-                    sock->sk->recv_wait.sleeping, sock->sk->receive_queue.qlen, \
+                    sock->sk->sport, sock->sk->dport, \
+                    sock->sk->receive_queue.qlen, \
                     sock->sk->write_queue.qlen, ##__VA_ARGS__);         \
     } while (0)
 #else

--- a/include/socket.h
+++ b/include/socket.h
@@ -60,6 +60,7 @@ struct socket {
     struct list_head list;
     int fd;
     pid_t pid;
+    int refcnt;
     enum socket_state state;
     short type;
     int flags;
@@ -84,6 +85,10 @@ int _getsockname(pid_t pid, int socket, struct sockaddr *restrict address,
                  socklen_t *restrict address_len);
 
 struct socket *socket_lookup(uint16_t sport, uint16_t dport);
+struct socket *socket_find(struct socket *sock);
+int socket_rd_acquire(struct socket *sock);
+int socket_wr_acquire(struct socket *sock);
+int socket_release(struct socket *sock);
 int socket_free(struct socket *sock);
 int socket_delete(struct socket *sock);
 void abort_sockets();

--- a/include/tcp.h
+++ b/include/tcp.h
@@ -34,10 +34,10 @@
 extern const char *tcp_dbg_states[];
 #define tcp_in_dbg(hdr, sk, skb)                                        \
     do {                                                                \
-        print_debug("TCP %hhu.%hhu.%hhu.%hhu.%u > %hhu.%hhu.%hhu.%hhu.%u: " \
-                    "Flags [S%hhuA%hhuP%hhuF%hhuR%hhu], seq %u:%u, ack %u, win %u rto %d boff %d", \
-                    sk->daddr >> 24, sk->daddr >> 16, sk->daddr >> 8, sk->daddr >> 0, sk->dport, \
-                    sk->saddr >> 24, sk->saddr >> 16, sk->saddr >> 8, sk->saddr >> 0, sk->sport, \
+        print_debug("TCP %u.%u.%u.%u.%u > %u.%u.%u.%u.%u: " \
+                    "Flags [S%uA%uP%uF%uR%u], seq %u:%u, ack %u, win %u rto %d boff %d", \
+                    (uint8_t)(sk->daddr >> 24), (uint8_t)(sk->daddr >> 16), (uint8_t)(sk->daddr >> 8), (uint8_t)(sk->daddr >> 0), sk->dport, \
+                    (uint8_t)(sk->saddr >> 24), (uint8_t)(sk->saddr >> 16), (uint8_t)(sk->saddr >> 8), (uint8_t)(sk->saddr >> 0), sk->sport, \
                     hdr->syn, hdr->ack, hdr->psh, hdr->fin, hdr->rst, hdr->seq - tcp_sk(sk)->tcb.irs, \
                     hdr->seq + skb->dlen - tcp_sk(sk)->tcb.irs,         \
                     hdr->ack_seq - tcp_sk(sk)->tcb.iss, hdr->win, tcp_sk(sk)->rto, tcp_sk(sk)->backoff); \
@@ -45,10 +45,10 @@ extern const char *tcp_dbg_states[];
 
 #define tcp_out_dbg(hdr, sk, skb)                                       \
     do {                                                                \
-        print_debug("TCP %hhu.%hhu.%hhu.%hhu.%u > %hhu.%hhu.%hhu.%hhu.%u: " \
-                    "Flags [S%hhuA%hhuP%hhuF%hhuR%hhu], seq %u:%u, ack %u, win %u rto %d boff %d", \
-                    sk->saddr >> 24, sk->saddr >> 16, sk->saddr >> 8, sk->saddr >> 0, sk->sport, \
-                    sk->daddr >> 24, sk->daddr >> 16, sk->daddr >> 8, sk->daddr >> 0, sk->dport, \
+        print_debug("TCP %u.%u.%u.%u.%u > %u.%u.%u.%u.%u: " \
+                    "Flags [S%uA%uP%uF%uR%u], seq %u:%u, ack %u, win %u rto %d boff %d", \
+                    (uint8_t)(sk->saddr >> 24), (uint8_t)(sk->saddr >> 16), (uint8_t)(sk->saddr >> 8), (uint8_t)(sk->saddr >> 0), sk->sport, \
+                    (uint8_t)(sk->daddr >> 24), (uint8_t)(sk->daddr >> 16), (uint8_t)(sk->daddr >> 8), (uint8_t)(sk->daddr >> 0), sk->dport, \
                     hdr->syn, hdr->ack, hdr->psh, hdr->fin, hdr->rst, hdr->seq - tcp_sk(sk)->tcb.iss, \
                     hdr->seq + skb->dlen - tcp_sk(sk)->tcb.iss,         \
                     hdr->ack_seq - tcp_sk(sk)->tcb.irs, hdr->win, tcp_sk(sk)->rto, tcp_sk(sk)->backoff); \
@@ -56,10 +56,10 @@ extern const char *tcp_dbg_states[];
 
 #define tcpsock_dbg(msg, sk)                                            \
     do {                                                                \
-        print_debug("TCP x:%u > %hhu.%hhu.%hhu.%hhu.%u (snd_una %u, snd_nxt %u, snd_wnd %u, " \
+        print_debug("TCP x:%u > %u.%u.%u.%u.%u (snd_una %u, snd_nxt %u, snd_wnd %u, " \
                     "snd_wl1 %u, snd_wl2 %u, rcv_nxt %u, rcv_wnd %u recv-q %d send-q %d " \
                     "rto %d boff %d) state %s: "msg, \
-                    sk->sport, sk->daddr >> 24, sk->daddr >> 16, sk->daddr >> 8, sk->daddr >> 0, \
+                    sk->sport, (uint8_t)(sk->daddr >> 24), (uint8_t)(sk->daddr >> 16), (uint8_t)(sk->daddr >> 8), (uint8_t)(sk->daddr >> 0), \
                     sk->dport, tcp_sk(sk)->tcb.snd_una - tcp_sk(sk)->tcb.iss,      \
                     tcp_sk(sk)->tcb.snd_nxt - tcp_sk(sk)->tcb.iss, tcp_sk(sk)->tcb.snd_wnd, \
                     tcp_sk(sk)->tcb.snd_wl1, tcp_sk(sk)->tcb.snd_wl2,   \

--- a/include/tcp.h
+++ b/include/tcp.h
@@ -203,6 +203,8 @@ struct tcp_sock {
     uint16_t smss;
     uint16_t cwnd;
     uint32_t inflight;
+
+    uint8_t sackok;
     
     struct sk_buff_head ofo_queue; /* Out-of-order queue */
 };

--- a/include/tcp.h
+++ b/include/tcp.h
@@ -21,8 +21,11 @@
 #define TCP_SYN_BACKOFF 500
 #define TCP_CONN_RETRIES 3
 
+#define TCP_OPT_NOOP 1
 #define TCP_OPTLEN_MSS 4
 #define TCP_OPT_MSS 2
+#define TCP_OPT_SACK_OK 4
+#define TCP_OPTLEN_SACK 2
 
 #define TCP_2MSL 60000
 #define TCP_USER_TIMEOUT 180000
@@ -119,6 +122,7 @@ struct tcphdr {
 struct tcp_options {
     uint16_t options;
     uint16_t mss;
+    uint8_t sack;
 };
 
 struct tcp_opt_mss {

--- a/include/tcp.h
+++ b/include/tcp.h
@@ -25,6 +25,7 @@
 #define TCP_OPTLEN_MSS 4
 #define TCP_OPT_MSS 2
 #define TCP_OPT_SACK_OK 4
+#define TCP_OPT_SACK 5
 #define TCP_OPTLEN_SACK 2
 
 #define TCP_2MSL 60000
@@ -184,6 +185,13 @@ struct tcb {
     uint32_t irs;
 };
 
+struct tcp_sack_block {
+    uint32_t left;
+    uint32_t right;
+    struct tcp_sack_block *next;
+} __attribute__((packed));
+
+
 struct tcp_sock {
     struct sock sk;
     int fd;
@@ -205,6 +213,7 @@ struct tcp_sock {
     uint32_t inflight;
 
     uint8_t sackok;
+    struct tcp_sack_block sacks[4];
     
     struct sk_buff_head ofo_queue; /* Out-of-order queue */
 };
@@ -255,5 +264,6 @@ void tcp_release_rto_timer(struct tcp_sock *tsk);
 void tcp_stop_delack_timer(struct tcp_sock *tsk);
 void tcp_release_delack_timer(struct tcp_sock *tsk);
 void tcp_rearm_user_timeout(struct sock *sk);
+int tcp_calculate_sacks(struct tcp_sock *tsk);
 
 #endif

--- a/include/tcp.h
+++ b/include/tcp.h
@@ -27,6 +27,7 @@
 #define TCP_OPT_SACK_OK 4
 #define TCP_OPT_SACK 5
 #define TCP_OPTLEN_SACK 2
+#define TCP_OPT_TS 8
 
 #define TCP_2MSL 60000
 #define TCP_USER_TIMEOUT 180000
@@ -214,6 +215,9 @@ struct tcp_sock {
 
     uint8_t sackok;
     struct tcp_sack_block sacks[4];
+    uint8_t sacklen;
+
+    uint8_t tsopt;
     
     struct sk_buff_head ofo_queue; /* Out-of-order queue */
 };

--- a/include/tcp.h
+++ b/include/tcp.h
@@ -189,9 +189,7 @@ struct tcb {
 struct tcp_sack_block {
     uint32_t left;
     uint32_t right;
-    struct tcp_sack_block *next;
 } __attribute__((packed));
-
 
 struct tcp_sock {
     struct sock sk;
@@ -214,8 +212,9 @@ struct tcp_sock {
     uint32_t inflight;
 
     uint8_t sackok;
-    struct tcp_sack_block sacks[4];
+    uint8_t sacks_allowed;
     uint8_t sacklen;
+    struct tcp_sack_block sacks[4];
 
     uint8_t tsopt;
     

--- a/include/tcp.h
+++ b/include/tcp.h
@@ -74,11 +74,25 @@ extern const char *tcp_dbg_states[];
         __tcp_set_state(sk, state);                                     \
     } while (0)
 
+#define return_tcp_drop(sk, skb)                          \
+    do {                                                  \
+        tcpsock_dbg("dropping packet", sk);               \
+        return __tcp_drop(sk, skb);                       \
+    } while (0)
+
+#define tcp_drop(tsk, skb)                      \
+    do {                                        \
+        tcpsock_dbg("dropping packet", sk);               \
+        __tcp_drop(tsk, skb);                   \
+    } while (0)
+
 #else
 #define tcp_in_dbg(hdr, sk, skb)
 #define tcp_out_dbg(hdr, sk, skb)
 #define tcpsock_dbg(msg, sk)
 #define tcp_set_state(sk, state)  __tcp_set_state(sk, state)
+#define return_tcp_drop(tsk, skb) return __tcp_drop(tsk, skb)
+#define tcp_drop(tsk, skb) __tcp_drop(tsk, skb)
 #endif
 
 struct tcphdr {

--- a/include/wait.h
+++ b/include/wait.h
@@ -28,12 +28,8 @@ static inline int wait_wakeup(struct wait_lock *w) {
 };
 
 static inline int wait_sleep(struct wait_lock *w) {
-    pthread_mutex_lock(&w->lock);
-
     w->sleeping = 1;
     pthread_cond_wait(&w->ready, &w->lock);
-
-    pthread_mutex_unlock(&w->lock);
     
     return 0;
 };

--- a/src/inet.c
+++ b/src/inet.c
@@ -86,8 +86,7 @@ static int inet_stream_connect(struct socket *sock, const struct sockaddr *addr,
 
     if (addr->sa_family == AF_UNSPEC) {
         sk->ops->disconnect(sk, flags);
-        sock->state = sk->err ? SS_DISCONNECTING : SS_UNCONNECTED;
-        goto out;
+        return -EAFNOSUPPORT;
     }
 
     switch (sock->state) {
@@ -136,7 +135,6 @@ out:
     return sk->err;
 sock_error:
     rc = sk->err;
-    socket_free(sock);
     return rc;
 }
 

--- a/src/inet.c
+++ b/src/inet.c
@@ -113,9 +113,9 @@ static int inet_stream_connect(struct socket *sock, const struct sockaddr *addr,
             goto out;
         }
 
-        pthread_rwlock_unlock(&sock->lock);
+        socket_release(sock);
         wait_sleep(&sock->sleep);
-        pthread_rwlock_wrlock(&sock->lock);
+        socket_wr_acquire(sock);
         
         switch (sk->err) {
         case -ETIMEDOUT:

--- a/src/ip_output.c
+++ b/src/ip_output.c
@@ -16,11 +16,11 @@ int ip_output(struct sock *sk, struct sk_buff *skb)
     struct rtentry *rt;
     struct iphdr *ihdr = ip_hdr(skb);
 
-    rt = route_lookup(ihdr->daddr);
+    rt = route_lookup(sk->daddr);
 
     if (!rt) {
-        // Raise error
         // TODO: dest_unreachable
+        print_err("IP output route lookup fail\n");
         return -1;
     }
 

--- a/src/ip_output.c
+++ b/src/ip_output.c
@@ -34,8 +34,7 @@ int ip_output(struct sock *sk, struct sk_buff *skb)
     ihdr->tos = 0;
     ihdr->len = skb->len;
     ihdr->id = ihdr->id;
-    ihdr->flags = 0;
-    ihdr->frag_offset = 0;
+    ihdr->frag_offset = 0x4000;
     ihdr->ttl = 64;
     ihdr->proto = skb->protocol;
     ihdr->saddr = skb->dev->addr;
@@ -49,6 +48,7 @@ int ip_output(struct sock *sk, struct sk_buff *skb)
     ihdr->daddr = htonl(ihdr->daddr);
     ihdr->saddr = htonl(ihdr->saddr);
     ihdr->csum = htons(ihdr->csum);
+    ihdr->frag_offset = htons(ihdr->frag_offset);
 
     ip_send_check(ihdr);
 

--- a/src/route.c
+++ b/src/route.c
@@ -50,7 +50,7 @@ struct rtentry *route_lookup(uint32_t daddr)
 
     list_for_each(item, &routes) {
         rt = list_entry(item, struct rtentry, list);
-        if ((rt->netmask & daddr) == rt->dst) break;
+        if ((daddr & rt->netmask) == (rt->dst & rt->netmask)) break;
         // If no matches, we default to to default gw (last item)
     }
     

--- a/src/sock.c
+++ b/src/sock.c
@@ -21,7 +21,6 @@ void sock_init_data(struct socket *sock, struct sock *sk)
     wait_init(&sk->recv_wait);
     skb_queue_init(&sk->receive_queue);
     skb_queue_init(&sk->write_queue);
-    pthread_mutex_init(&sk->lock, NULL);
 
     sk->poll_events = 0;
 
@@ -32,7 +31,6 @@ void sock_free(struct sock *sk)
 {
     skb_queue_free(&sk->receive_queue);
     skb_queue_free(&sk->write_queue);
-    pthread_mutex_destroy(&sk->lock);
 }
 
 void sock_connected(struct sock *sk)

--- a/src/socket.c
+++ b/src/socket.c
@@ -48,6 +48,7 @@ int socket_free(struct socket *sock)
     }
 
     wait_free(&sock->sleep);
+    pthread_rwlock_unlock(&sock->lock);    
     
     free(sock);
     
@@ -63,7 +64,6 @@ static void *socket_garbage_collect(void *arg)
     socket_dbg(sock, "Garbage collecting (freeing) socket");
     socket_free(sock);
 
-    pthread_rwlock_unlock(&sock->lock);    
     pthread_rwlock_unlock(&slock);
 
     return NULL;

--- a/src/socket.c
+++ b/src/socket.c
@@ -40,6 +40,9 @@ static struct socket *alloc_socket(pid_t pid)
 
 int socket_free(struct socket *sock)
 {
+    list_del(&sock->list);
+    sock_amount--;
+
     if (sock->ops) {
         sock->ops->free(sock);
     }
@@ -58,13 +61,10 @@ static void *socket_garbage_collect(void *arg)
     pthread_rwlock_wrlock(&slock);
     pthread_rwlock_wrlock(&sock->lock);
     socket_dbg(sock, "Garbage collecting (freeing) socket");
-
-    list_del(&sock->list);
-    sock_amount--;
+    socket_free(sock);
 
     pthread_rwlock_unlock(&sock->lock);    
     pthread_rwlock_unlock(&slock);
-    socket_free(sock);
 
     return NULL;
 }

--- a/src/tcp.c
+++ b/src/tcp.c
@@ -117,9 +117,9 @@ struct sock *tcp_alloc_sock()
 
     tsk->delacks = 0;
 
-    /* TODO: Determine mss properly */
     tsk->rmss = 1460;
-    tsk->smss = 1300;
+    // Default to 536 as per spec
+    tsk->smss = 536;
 
     tsk->cwnd = 0;
     tsk->inflight = 0;

--- a/src/tcp.c
+++ b/src/tcp.c
@@ -110,6 +110,7 @@ struct sock *tcp_alloc_sock()
     tsk->sk.state = TCP_CLOSE;
     tsk->flags = 0;
     tsk->backoff = 0;
+    tsk->sackok = 0;
 
     tsk->retransmit = NULL;
     tsk->delack = NULL;

--- a/src/tcp.c
+++ b/src/tcp.c
@@ -108,24 +108,11 @@ struct sock *tcp_alloc_sock()
 
     memset(tsk, 0, sizeof(struct tcp_sock));
     tsk->sk.state = TCP_CLOSE;
-    tsk->flags = 0;
-    tsk->backoff = 0;
     tsk->sackok = 1;
-    tsk->sacklen = 0;
-    tsk->tsopt = 0;
     
-    tsk->retransmit = NULL;
-    tsk->delack = NULL;
-    tsk->keepalive = NULL;
-
-    tsk->delacks = 0;
-
     tsk->rmss = 1460;
     // Default to 536 as per spec
     tsk->smss = 536;
-
-    tsk->cwnd = 0;
-    tsk->inflight = 0;
 
     skb_queue_init(&tsk->ofo_queue);
     

--- a/src/tcp.c
+++ b/src/tcp.c
@@ -461,3 +461,33 @@ void tcp_rtt(struct tcp_sock *tsk)
 
     tsk->rto = tsk->srtt + k;
 }
+
+int tcp_calculate_sacks(struct tcp_sock *tsk)
+{
+//    struct tcb *tcb = &tsk->tcb;
+
+    int sack_idx = 0;
+    struct tcp_sack_block *sb = &tsk->sacks[sack_idx];
+
+    sb->left = 0;
+    sb->right = 0;
+
+    struct sk_buff *next;
+    struct list_head *item, *tmp;
+
+    list_for_each_safe(item, tmp, &tsk->ofo_queue.head) {
+        next = list_entry(item, struct sk_buff, list);
+
+        printf("sb->left edge %u, right %u, next seq %u, next end seq %u\n", sb->left, sb->right, next->seq, next->end_seq);
+
+        if (sb->left == 0) sb->left = next->seq;
+        if (sb->right == 0) sb->right = next->end_seq;
+        else if (sb->right == next->seq) sb->right = next->end_seq;
+        else {
+            printf("Gap in ofo queue\n");
+            break;
+        }
+    }
+    
+    return 0;
+}

--- a/src/tcp.c
+++ b/src/tcp.c
@@ -111,6 +111,9 @@ struct sock *tcp_alloc_sock()
     tsk->flags = 0;
     tsk->backoff = 0;
     tsk->sackok = 1;
+    tsk->sacklen = 0;
+    tsk->tsopt = 0;
+    
     tsk->retransmit = NULL;
     tsk->delack = NULL;
     tsk->keepalive = NULL;

--- a/src/tcp.c
+++ b/src/tcp.c
@@ -395,7 +395,7 @@ static void *tcp_linger(void *arg)
     tcpsock_dbg("TCP time-wait timeout, freeing TCB", sk);
 
     pthread_mutex_lock(&sk->lock);
-    timer_release(tsk->linger);
+    timer_cancel(tsk->linger);
     tsk->linger = NULL;
     pthread_mutex_unlock(&sk->lock);
 
@@ -413,7 +413,7 @@ static void *tcp_user_timeout(void *arg)
     tcpsock_dbg("TCP user timeout, freeing TCB and aborting conn", sk);
 
     pthread_mutex_lock(&sk->lock);
-    timer_release(tsk->linger);
+    timer_cancel(tsk->linger);
     tsk->linger = NULL;
     pthread_mutex_unlock(&sk->lock);
 

--- a/src/tcp.c
+++ b/src/tcp.c
@@ -110,8 +110,7 @@ struct sock *tcp_alloc_sock()
     tsk->sk.state = TCP_CLOSE;
     tsk->flags = 0;
     tsk->backoff = 0;
-    tsk->sackok = 0;
-
+    tsk->sackok = 1;
     tsk->retransmit = NULL;
     tsk->delack = NULL;
     tsk->keepalive = NULL;

--- a/src/tcp.c
+++ b/src/tcp.c
@@ -464,8 +464,6 @@ int tcp_calculate_sacks(struct tcp_sock *tsk)
     list_for_each_safe(item, tmp, &tsk->ofo_queue.head) {
         next = list_entry(item, struct sk_buff, list);
 
-        printf("sb->left edge %u, right %u, next seq %u, next end seq %u\n", sb->left, sb->right, next->seq, next->end_seq);
-
         if (sb->left == 0) {
             sb->left = next->seq;
             tsk->sacklen++;

--- a/src/tcp_data.c
+++ b/src/tcp_data.c
@@ -110,6 +110,7 @@ int tcp_data_queue(struct tcp_sock *tsk, struct tcphdr *th, struct sk_buff *skb)
 
         // There is new data for user to read
         sk->poll_events |= (POLLIN | POLLPRI | POLLRDNORM | POLLRDBAND);
+        tsk->sk.ops->recv_notify(&tsk->sk);
     } else {
         /* Segment passed validation, hence it is in-window
            but not the left-most sequence. Put into out-of-order queue

--- a/src/tcp_data.c
+++ b/src/tcp_data.c
@@ -52,8 +52,6 @@ int tcp_data_dequeue(struct tcp_sock *tsk, void *user_buf, int userlen)
     struct tcphdr *th;
     int rlen = 0;
 
-    pthread_mutex_lock(&sk->receive_queue.lock);
-
     while (!skb_queue_empty(&sk->receive_queue) && rlen < userlen) {
         struct sk_buff *skb = skb_peek(&sk->receive_queue);
         if (skb == NULL) break;
@@ -83,8 +81,6 @@ int tcp_data_dequeue(struct tcp_sock *tsk, void *user_buf, int userlen)
         sk->poll_events &= ~POLLIN;
     }
     
-    pthread_mutex_unlock(&sk->receive_queue.lock);
-
     return rlen;
 }
 

--- a/src/tcp_data.c
+++ b/src/tcp_data.c
@@ -113,6 +113,10 @@ int tcp_data_queue(struct tcp_sock *tsk, struct tcphdr *th, struct sk_buff *skb)
            for later processing */
         tcp_data_insert_ordered(&tsk->ofo_queue, skb);
 
+        if (tsk->sackok) {
+            tcp_calculate_sacks(tsk); 
+        }
+        
         /* RFC5581: A TCP receiver SHOULD send an immediate duplicate ACK when an out-
          * of-order segment arrives.  The purpose of this ACK is to inform the
          * sender that a segment was received out-of-order and which sequence

--- a/src/tcp_input.c
+++ b/src/tcp_input.c
@@ -351,7 +351,6 @@ int tcp_input_state(struct sock *sk, struct tcphdr *th, struct sk_buff *skb)
     case TCP_FIN_WAIT_2:
         if (th->psh || skb->dlen > 0) {
             tcp_data_queue(tsk, th, skb);
-            tsk->sk.ops->recv_notify(&tsk->sk);
         }
                 
         break;

--- a/src/tcp_input.c
+++ b/src/tcp_input.c
@@ -15,7 +15,7 @@ static int tcp_clean_rto_queue(struct sock *sk, uint32_t una)
     int rc = 0;
     
     while ((skb = skb_peek(&sk->write_queue)) != NULL) {
-        if (skb->end_seq <= una) {
+        if (skb->seq > 0 && skb->end_seq <= una) {
             /* skb fully acknowledged */
             skb_dequeue(&sk->write_queue);
             skb->refcnt--;

--- a/src/tcp_input.c
+++ b/src/tcp_input.c
@@ -447,7 +447,7 @@ int tcp_input_state(struct sock *sk, struct tcphdr *th, struct sk_buff *skb)
             } else {
                 tcp_set_state(sk, TCP_CLOSING);
             }
-            
+
             break;
         case TCP_FIN_WAIT_2:
             /* Enter the TIME-WAIT state.  Start the time-wait timer, turn

--- a/src/tcp_input.c
+++ b/src/tcp_input.c
@@ -50,8 +50,8 @@ static int tcp_parse_opts(struct tcp_sock *tsk, struct tcphdr *th)
 
     if (sack_seen && tsk->sackok) {
         // There's room for 4 sack blocks without TS OPT
-        if (tsk->tsopt) tsk->sacklen = 3;
-        else tsk->sacklen = 4;
+        if (tsk->tsopt) tsk->sacks_allowed = 3;
+        else tsk->sacks_allowed = 4;
     } else {
         tsk->sackok = 0;
     }

--- a/src/tcp_input.c
+++ b/src/tcp_input.c
@@ -474,8 +474,10 @@ int tcp_receive(struct tcp_sock *tsk, void *buf, int len)
             
             break;
         } else {
+            pthread_mutex_lock(&tsk->sk.recv_wait.lock);
             socket_release(sock);
             wait_sleep(&tsk->sk.recv_wait);
+            pthread_mutex_unlock(&tsk->sk.recv_wait.lock);
             socket_wr_acquire(sock);
         }
     }

--- a/src/tcp_input.c
+++ b/src/tcp_input.c
@@ -28,7 +28,6 @@ static int tcp_parse_opts(struct tcp_sock *tsk, struct tcphdr *th)
             optlen--;
             break;
         case TCP_OPT_SACK_OK:
-            tsk->sackok = 1;
             optlen--;
             break;
         default:

--- a/src/tcp_input.c
+++ b/src/tcp_input.c
@@ -474,9 +474,9 @@ int tcp_receive(struct tcp_sock *tsk, void *buf, int len)
             
             break;
         } else {
-            pthread_rwlock_unlock(&sock->lock);
+            socket_release(sock);
             wait_sleep(&tsk->sk.recv_wait);
-            pthread_rwlock_wrlock(&sock->lock);
+            socket_wr_acquire(sock);
         }
     }
 

--- a/src/tcp_output.c
+++ b/src/tcp_output.c
@@ -214,7 +214,7 @@ static int tcp_options_len(struct sock *sk)
     uint8_t optlen = 0;
 
     if (tsk->sackok) {
-        for (int i = 0; i < 4; i++) {
+        for (int i = 0; i < tsk->sacklen; i++) {
             if (tsk->sacks[i].left != 0) {
                 optlen += 32;
             }

--- a/src/tcp_output.c
+++ b/src/tcp_output.c
@@ -88,7 +88,7 @@ static int tcp_queue_transmit_skb(struct sock *sk, struct sk_buff *skb)
         tcp_rearm_rto_timer(tsk);
     }
 
-    if (tsk->inflight < 3) {
+    if (tsk->inflight == 0) {
         /* Store sequence information into the socket buffer */
         rc = tcp_transmit_skb(sk, skb, tcb->snd_nxt);
         tsk->inflight++;

--- a/src/tcp_output.c
+++ b/src/tcp_output.c
@@ -104,7 +104,9 @@ static int tcp_transmit_skb(struct sock *sk, struct sk_buff *skb, uint32_t seq)
     thdr->csum = 0;
     thdr->urp = 0;
 
-    tcp_write_options(tsk, thdr);
+    if (thdr->hl > 5) {
+        tcp_write_options(tsk, thdr);
+    }
 
     tcp_out_dbg(thdr, sk, skb);
 
@@ -216,12 +218,14 @@ static int tcp_options_len(struct sock *sk)
     if (tsk->sackok) {
         for (int i = 0; i < tsk->sacklen; i++) {
             if (tsk->sacks[i].left != 0) {
-                optlen += 32;
+                optlen += 8;
             }
         }
+
+        optlen += 2;
     }
 
-    if (optlen == 32) optlen += 8;
+    while (optlen % 4 > 0) optlen++;
 
     return optlen;
 }

--- a/src/tcp_output.c
+++ b/src/tcp_output.c
@@ -51,9 +51,13 @@ static int tcp_syn_options(struct sock *sk, struct tcp_options *opts)
     opts->mss = tsk->rmss;
     optlen += TCP_OPTLEN_MSS;
 
-    opts->sack = 1;
-    optlen += TCP_OPT_NOOP * 2;
-    optlen += TCP_OPTLEN_SACK;
+    if (tsk->sackok) {
+        opts->sack = 1;
+        optlen += TCP_OPT_NOOP * 2;
+        optlen += TCP_OPTLEN_SACK;
+    } else {
+        opts->sack = 0;
+    }
     
     return optlen;
 }

--- a/tests/suites/arp/suite-arp
+++ b/tests/suites/arp/suite-arp
@@ -4,19 +4,8 @@ set -eu
 
 source "$(dirname $0)/../../utils/common"
 
-function setup {
-    start_stack
-}
-
-function teardown {
-    kill "$stackip"
-}
-
 function test_arp {
     arping -c3 -I tap0 10.0.0.4 >/dev/null
 }
 
-trap teardown EXIT ERR
-setup
-
-test_run "test_arp"
+test_run "test_arp" "$0"

--- a/tests/suites/icmp/suite-icmp
+++ b/tests/suites/icmp/suite-icmp
@@ -4,19 +4,8 @@ set -eu
 
 source "$(dirname $0)/../../utils/common"
 
-function setup {
-    start_stack
-}
-
-function teardown {
-    kill "$stackip"
-}
-
 function test_ping {
     ping -c3 -I tap0 10.0.0.4 > /dev/null
 }
 
-setup
-trap teardown EXIT ERR
-
-test_run "test_ping"
+test_run "test_ping" "$0"

--- a/tests/suites/tcp/env-delayed
+++ b/tests/suites/tcp/env-delayed
@@ -10,20 +10,20 @@ function strip_http_header {
 }
 
 function setup {
-    start_stack
-
-    /usr/bin/env python2.7 -m SimpleHTTPServer >/dev/null 2>&1 &
+    /usr/bin/env python2.7 -m SimpleHTTPServer 8002 >/dev/null 2>&1 &
     httpserver="$!"
 
-    sleep 10
+    tc class add dev tap0 parent 1: classid 1:1 htb rate 100mbit
+    tc filter add dev tap0 parent 1: protocol ip prio 1 u32 flowid 1:1 match ip sport 8002 0xffff
+    tc filter add dev tap0 parent 1: protocol ip prio 1 u32 flowid 1:1 match ip dport 8002 0xffff
+    tc qdisc add dev tap0 parent 1:1 netem delay 2000ms
 
-    tc qdisc add dev tap0 root netem delay 2000ms 
+    sleep 5
 }
 
-function teardown {
-    kill "$stackip"
+function teardown_suite {
     kill "$httpserver"
 }
 
+trap teardown_suite EXIT ERR
 setup
-trap teardown EXIT ERR

--- a/tests/suites/tcp/env-duplication
+++ b/tests/suites/tcp/env-duplication
@@ -10,20 +10,20 @@ function strip_http_header {
 }
 
 function setup {
-    start_stack
-
-    /usr/bin/env python2.7 -m SimpleHTTPServer >/dev/null 2>&1 &
+    /usr/bin/env python2.7 -m SimpleHTTPServer 8003 >/dev/null 2>&1 &
     httpserver="$!"
 
-    sleep 15
+    tc class add dev tap0 parent 1: classid 1:2 htb rate 100mbit
+    tc filter add dev tap0 parent 1: protocol ip prio 1 u32 flowid 1:2 match ip sport 8003 0xffff
+    tc filter add dev tap0 parent 1: protocol ip prio 1 u32 flowid 1:2 match ip dport 8003 0xffff
+    tc qdisc add dev tap0 parent 1:2 netem duplicate 50%
 
-    tc qdisc add dev tap0 root netem duplicate 50%
+    sleep 5
 }
 
-function teardown {
-    kill "$stackip"
+function teardown_suite {
     kill "$httpserver"
 }
 
+trap teardown_suite EXIT ERR
 setup
-trap teardown EXIT ERR

--- a/tests/suites/tcp/env-lossy
+++ b/tests/suites/tcp/env-lossy
@@ -10,20 +10,20 @@ function strip_http_header {
 }
 
 function setup {
-    start_stack
-
-    /usr/bin/env python2.7 -m SimpleHTTPServer >/dev/null 2>&1 &
+    /usr/bin/env python2.7 -m SimpleHTTPServer 8004 >/dev/null 2>&1 &
     httpserver="$!"
 
-    sleep 10
+    tc class add dev tap0 parent 1: classid 1:3 htb rate 100mbit
+    tc filter add dev tap0 parent 1: protocol ip prio 1 u32 flowid 1:3 match ip sport 8004 0xffff
+    tc filter add dev tap0 parent 1: protocol ip prio 1 u32 flowid 1:3 match ip dport 8004 0xffff
+    tc qdisc add dev tap0 parent 1:3 netem loss 25%
 
-    tc qdisc add dev tap0 root netem loss 25%
+    sleep 5
 }
 
-function teardown {
-    kill "$stackip"
+function teardown_suite {
     kill "$httpserver"
 }
 
+trap teardown_suite EXIT ERR
 setup
-trap teardown EXIT ERR

--- a/tests/suites/tcp/env-normal
+++ b/tests/suites/tcp/env-normal
@@ -10,18 +10,15 @@ function strip_http_header {
 }
 
 function setup {
-    start_stack
-
-    /usr/bin/env python2.7 -m SimpleHTTPServer >/dev/null 2>&1 &
+    /usr/bin/env python2.7 -m SimpleHTTPServer 8001 >/dev/null 2>&1 &
     httpserver="$!"
 
-    sleep 10
+    sleep 5
 }
 
-function teardown {
-    kill "$stackip"
+function teardown_suite {
     kill "$httpserver"
 }
 
 setup
-trap teardown EXIT ERR
+trap teardown_suite EXIT ERR

--- a/tests/suites/tcp/suite-curl
+++ b/tests/suites/tcp/suite-curl
@@ -3,4 +3,4 @@
 set -eu
 
 source "$(dirname $0)/env-normal"
-source "$(dirname $0)/tests"
+source "$(dirname $0)/tests" 8001 "$0"

--- a/tests/suites/tcp/suite-packet-delay
+++ b/tests/suites/tcp/suite-packet-delay
@@ -3,4 +3,4 @@
 set -eu
 
 source "$(dirname $0)/env-delayed"
-source "$(dirname $0)/tests"
+source "$(dirname $0)/tests" 8002 "$0"

--- a/tests/suites/tcp/suite-packet-duplication
+++ b/tests/suites/tcp/suite-packet-duplication
@@ -3,4 +3,4 @@
 set -eu
 
 source "$(dirname $0)/env-duplication"
-source "$(dirname $0)/tests"
+source "$(dirname $0)/tests" 8003 "$0"

--- a/tests/suites/tcp/suite-packet-loss
+++ b/tests/suites/tcp/suite-packet-loss
@@ -3,4 +3,4 @@
 set -eu
 
 source "$(dirname $0)/env-lossy"
-source "$(dirname $0)/tests"
+source "$(dirname $0)/tests" 8004 "$0"

--- a/tests/suites/tcp/tests
+++ b/tests/suites/tcp/tests
@@ -2,14 +2,17 @@
 
 set -eu
 
+port="$1"
+suite="$2"
+
 function test_synchronous_http_get {
-    response="$("$repo/tools/level-ip" "$repo/apps/curl/curl" 10.0.0.5 8000 | strip_http_header)"
+    response="$("$repo/tools/level-ip" "$repo/apps/curl/curl" 10.0.0.5 $port | strip_http_header)"
 
     diff "$folder/curl-fixture.txt" <(echo "$response")
 }
 
 function test_poll_http_get {
-    response="$("$repo/tools/level-ip" "$repo/apps/curl-poll/curl-poll" 10.0.0.5 8000 | strip_http_header)"
+    response="$("$repo/tools/level-ip" "$repo/apps/curl-poll/curl-poll" 10.0.0.5 $port | strip_http_header)"
 
     diff "$folder/curl-fixture.txt" <(echo "$response")
 }
@@ -18,6 +21,6 @@ function test_tcp_connection_refused {
     "$repo/tools/level-ip" "$repo/apps/curl/curl" 10.0.0.5 9999 2>&1 | grep -q "Connection refused"
 }
 
-test_run "test_synchronous_http_get"
-test_run "test_poll_http_get"
-test_run "test_tcp_connection_refused"
+test_run "test_synchronous_http_get" "$suite"
+test_run "test_poll_http_get" "$suite"
+test_run "test_tcp_connection_refused" "$suite"

--- a/tests/test-run-all
+++ b/tests/test-run-all
@@ -2,7 +2,41 @@
 
 set -eu
 
-for suite in suites/*/suite-*; do
-    echo "Running $suite"
-    "$suite"
+source "utils/common"
+
+function teardown {
+    echo "Shutting down lvl-ip"
+    kill "$stackip"
+}
+
+trap teardown EXIT ERR
+
+start_stack
+echo "Started lvl-ip with pid $stackip"
+sleep 5 # wait for stack to establish itself
+
+pids=""
+
+tc qdisc add dev tap0 root handle 1: htb
+
+./suites/arp/suite-arp &
+pids="$pids $!"
+./suites/icmp/suite-icmp &
+pids="$pids $!"
+./suites/tcp/suite-curl &
+pids="$pids $!"
+./suites/tcp/suite-packet-delay &
+pids="$pids $!"
+./suites/tcp/suite-packet-duplication &
+pids="$pids $!"
+./suites/tcp/suite-packet-loss &
+pids="$pids $!"
+
+rc=0
+for i in $pids; do
+  wait $i
+  pid_rc="$?"
+  [ "$pid_rc" -ne 0 ] && rc="$pid_rc"
 done
+
+exit "$rc"

--- a/tests/test-run-all
+++ b/tests/test-run-all
@@ -5,7 +5,6 @@ set -eu
 source "utils/common"
 
 function teardown {
-    echo "Shutting down lvl-ip"
     kill "$stackip"
 }
 
@@ -39,5 +38,8 @@ for i in $pids; do
   [ "$pid_rc" -ne 0 ] && rc="$pid_rc"
 done
 
-grep -i -B50 "SUMMARY: ThreadSanitizer:" ../lvl-ip-test.log
+grep -i -B50 "SUMMARY: ThreadSanitizer:" ../lvl-ip-test.log && echo "Possible threading errors found."
+
+echo
+[ "$rc" -eq 0 ] && echo "Tests pass."
 exit "$rc"

--- a/tests/test-run-all
+++ b/tests/test-run-all
@@ -1,4 +1,4 @@
-##!/bin/bash
+#!/bin/bash
 
 set -eu
 

--- a/tests/test-run-all
+++ b/tests/test-run-all
@@ -39,4 +39,5 @@ for i in $pids; do
   [ "$pid_rc" -ne 0 ] && rc="$pid_rc"
 done
 
+grep -i -B50 "SUMMARY: ThreadSanitizer:" ../lvl-ip-test.log && exit 1
 exit "$rc"

--- a/tests/test-run-all
+++ b/tests/test-run-all
@@ -39,5 +39,5 @@ for i in $pids; do
   [ "$pid_rc" -ne 0 ] && rc="$pid_rc"
 done
 
-grep -i -B50 "SUMMARY: ThreadSanitizer:" ../lvl-ip-test.log && exit 1
+grep -i -B50 "SUMMARY: ThreadSanitizer:" ../lvl-ip-test.log
 exit "$rc"

--- a/tests/utils/common
+++ b/tests/utils/common
@@ -9,14 +9,14 @@ function start_stack {
     "$repo/lvl-ip" > ../lvl-ip-test.log 2>&1 &
     stackip="$!"
 
-    sleep 2
-
-    for i in {1..10}; do
+    for i in {1..3}; do
         ping -c1 -w1 10.0.0.5 >/dev/null || continue
 
         return 0
     done
 
+    echo "Stack did not start up correctly" >&2
+    cat ../lvl-ip-test.log
     return 1
 }
 

--- a/tests/utils/common
+++ b/tests/utils/common
@@ -6,7 +6,7 @@ repo="$(git rev-parse --show-toplevel)"
 folder="$(dirname $0)"
 
 function start_stack {
-    "$repo/lvl-ip" >/dev/null &
+    "$repo/lvl-ip" > ../lvl-ip-test.log 2>&1 &
     stackip="$!"
 
     sleep 2
@@ -21,16 +21,16 @@ function start_stack {
 }
 
 function test_pass {
-    echo -e "\tTest pass: $1"
+    echo -e "\t$2 Test pass: $1"
 }
 
 function test_fail {
-    echo -e "\tTest fail: $1" 2>&1
+    echo -e "\t$2 Test fail: $1" 2>&1
     exit 1
 }
 
 function test_run {
-    eval "$1" || test_fail "$1"
+    eval "$1" || test_fail "$1" "$2"
 
-    test_pass "$1"
+    test_pass "$1" "$2"
 }


### PR DESCRIPTION
This change set includes important robustness fixes:

* Correct reference counting for tcp_linger (Fixes #13)
* Asynchronous test suites (speed increase and TSan reports)
* TCP SACK receiver behaviour (significantly reduces waiting on TCP retransmissions)

Plus other minor fixes (see commit log).